### PR TITLE
Append non-grant advances to PaymentsOnAccount

### DIFF
--- a/invoice_totals.go
+++ b/invoice_totals.go
@@ -157,6 +157,7 @@ func (it *InvoiceTotals) setAdvances(advances []*pay.Advance) {
 			if a.Date != nil {
 				na.PaymentOnAccountDate = *a.Date
 			}
+			regular = append(regular, na)
 		}
 	}
 	if len(regular) > 0 {

--- a/invoice_totals.go
+++ b/invoice_totals.go
@@ -112,7 +112,7 @@ func newInvoiceTotals(invoice *bill.Invoice) *InvoiceTotals {
 	*/
 
 	if invoice.Payment != nil {
-		xmlTotals.setAdvances(invoice.Payment.Advances)
+		xmlTotals.setAdvances(invoice.Payment.Advances, invoice.IssueDate)
 	}
 	// xmlTotals.setOutlays(invoice.Outlays)
 	xmlTotals.setTaxTotals(totals.Taxes)
@@ -137,7 +137,10 @@ func (it *InvoiceTotals) setTaxTotals(taxes *tax.Total) {
 	it.TotalTaxesWithheld = amount(retained)
 }
 
-func (it *InvoiceTotals) setAdvances(advances []*pay.Advance) {
+// setAdvances populates PaymentsOnAccount and Subsidies from the invoice's
+// advances. fallbackDate (the invoice's IssueDate) is used when a non-grant
+// advance has no date set.
+func (it *InvoiceTotals) setAdvances(advances []*pay.Advance, fallbackDate cal.Date) {
 	regular := make([]*PaymentOnAccount, 0)
 	grants := make([]*Subsidy, 0)
 	for _, a := range advances {
@@ -153,6 +156,7 @@ func (it *InvoiceTotals) setAdvances(advances []*pay.Advance) {
 		} else {
 			na := &PaymentOnAccount{
 				PaymentOnAccountAmount: amount(a.Amount),
+				PaymentOnAccountDate:   fallbackDate,
 			}
 			if a.Date != nil {
 				na.PaymentOnAccountDate = *a.Date

--- a/invoice_totals_test.go
+++ b/invoice_totals_test.go
@@ -3,7 +3,9 @@ package facturae_test
 import (
 	"testing"
 
+	facturae "github.com/invopop/gobl.facturae"
 	"github.com/invopop/gobl.facturae/test"
+	"github.com/invopop/gobl/bill"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,5 +26,23 @@ func TestInvoiceInvoiceTotals(t *testing.T) {
 		assert.Equal(t, "5084.42", xmlInvoice.InvoiceTotals.InvoiceTotal)
 		assert.Equal(t, "5084.42", xmlInvoice.InvoiceTotals.TotalOutstandingAmount)
 		assert.Equal(t, "5084.42", xmlInvoice.InvoiceTotals.TotalExecutableAmount)
+	})
+
+	t.Run("falls back to invoice IssueDate when an advance has no date", func(t *testing.T) {
+		env, err := test.LoadTestEnvelope("invoice-with-advance.json")
+		require.NoError(t, err)
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		require.NotEmpty(t, inv.Payment.Advances)
+		inv.Payment.Advances[0].Date = nil
+
+		doc, err := facturae.NewInvoice(env)
+		require.NoError(t, err)
+
+		poa := doc.Invoices.List[0].InvoiceTotals.PaymentsOnAccount
+		require.NotNil(t, poa)
+		require.Len(t, poa.PaymentOnAccount, 1)
+		assert.Equal(t, inv.IssueDate.String(), poa.PaymentOnAccount[0].PaymentOnAccountDate.String())
 	})
 }

--- a/test/data/invoice-with-advance.json
+++ b/test/data/invoice-with-advance.json
@@ -1,0 +1,148 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "7b2a6f80-7483-11ec-9722-7ea2cb436ff6",
+		"dig": {
+			"alg": "sha256",
+			"val": "7b2a6f80748311ec97227ea2cb436ff67b2a6f80748311ec97227ea2cb436ff6"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"$addons": [
+			"es-facturae-v3"
+		],
+		"uuid": "019c4e4d-1234-72e6-9579-55f09974a200",
+		"type": "standard",
+		"code": "TEST01001A",
+		"issue_date": "2021-12-08",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"es-facturae-doc-type": "FC",
+				"es-facturae-invoice-class": "OO"
+			}
+		},
+		"supplier": {
+			"name": "Hypeprop Sl",
+			"alias": "Hypeprop",
+			"tax_id": {
+				"country": "ES",
+				"code": "B23103039"
+			},
+			"addresses": [
+				{
+					"num": "74",
+					"street": "Campo Real",
+					"locality": "Torrejón De La Calzada",
+					"region": "Madrid",
+					"code": "28023",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "rxazy27xfc@iname.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Moniward Sl",
+			"tax_id": {
+				"country": "ES",
+				"code": "B77436020"
+			},
+			"addresses": [
+				{
+					"num": "35",
+					"street": "Plaza Horno",
+					"locality": "Nombela",
+					"region": "Toledo",
+					"code": "45083",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "bfn25xf3p@lycos.co.uk"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Operations and development - day rate",
+					"price": "200.00"
+				},
+				"sum": "4000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					}
+				],
+				"total": "4000.00"
+			}
+		],
+		"payment": {
+			"advances": [
+				{
+					"date": "2021-11-01",
+					"key": "credit-transfer",
+					"description": "Initial deposit",
+					"amount": "1000.00"
+				}
+			],
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2021-12-30",
+						"amount": "3840.00",
+						"percent": "100%"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "ES25 0188 2570 7185 4470 4761",
+						"name": "Bankrandom"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "4000.00",
+			"total": "4000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "4000.00",
+								"percent": "21.0%",
+								"amount": "840.00"
+							}
+						],
+						"amount": "840.00"
+					}
+				],
+				"sum": "840.00"
+			},
+			"tax": "840.00",
+			"total_with_tax": "4840.00",
+			"payable": "4840.00",
+			"advance": "1000.00",
+			"due": "3840.00"
+		}
+	}
+}

--- a/test/data/out/invoice-with-advance.xml
+++ b/test/data/out/invoice-with-advance.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fe:Facturae xmlns:fe="http://www.facturae.gob.es/formato/Versiones/Facturaev3_2_2.xml">
+	<FileHeader>
+		<SchemaVersion>3.2.2</SchemaVersion>
+		<Modality>I</Modality>
+		<InvoiceIssuerType>TE</InvoiceIssuerType>
+		<ThirdParty>
+			<TaxIdentification>
+				<PersonTypeCode>J</PersonTypeCode>
+				<ResidenceTypeCode>R</ResidenceTypeCode>
+				<TaxIdentificationNumber>B23103039</TaxIdentificationNumber>
+			</TaxIdentification>
+			<LegalEntity>
+				<CorporateName>Hypeprop S.L.</CorporateName>
+				<AddressInSpain>
+					<Address>Calle Campo Real 74</Address>
+					<PostCode>28023</PostCode>
+					<Town>Torrejón De La Calzada</Town>
+					<Province>Madrid</Province>
+					<CountryCode>ESP</CountryCode>
+				</AddressInSpain>
+			</LegalEntity>
+		</ThirdParty>
+		<Batch>
+			<BatchIdentifier>B23103039-TEST01001A</BatchIdentifier>
+			<InvoicesCount>1</InvoicesCount>
+			<TotalInvoicesAmount>
+				<TotalAmount>4840.00</TotalAmount>
+			</TotalInvoicesAmount>
+			<TotalOutstandingAmount>
+				<TotalAmount>4840.00</TotalAmount>
+			</TotalOutstandingAmount>
+			<TotalExecutableAmount>
+				<TotalAmount>4840.00</TotalAmount>
+			</TotalExecutableAmount>
+			<InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+		</Batch>
+	</FileHeader>
+	<Parties>
+		<SellerParty>
+			<TaxIdentification>
+				<PersonTypeCode>J</PersonTypeCode>
+				<ResidenceTypeCode>R</ResidenceTypeCode>
+				<TaxIdentificationNumber>B23103039</TaxIdentificationNumber>
+			</TaxIdentification>
+			<LegalEntity>
+				<CorporateName>Hypeprop Sl</CorporateName>
+				<AddressInSpain>
+					<Address>Campo Real, 74</Address>
+					<PostCode>28023</PostCode>
+					<Town>Torrejón De La Calzada</Town>
+					<Province>Madrid</Province>
+					<CountryCode>ESP</CountryCode>
+				</AddressInSpain>
+				<ContactDetails>
+					<ElectronicMail>rxazy27xfc@iname.com</ElectronicMail>
+				</ContactDetails>
+			</LegalEntity>
+		</SellerParty>
+		<BuyerParty>
+			<TaxIdentification>
+				<PersonTypeCode>J</PersonTypeCode>
+				<ResidenceTypeCode>R</ResidenceTypeCode>
+				<TaxIdentificationNumber>B77436020</TaxIdentificationNumber>
+			</TaxIdentification>
+			<LegalEntity>
+				<CorporateName>Moniward Sl</CorporateName>
+				<AddressInSpain>
+					<Address>Plaza Horno, 35</Address>
+					<PostCode>45083</PostCode>
+					<Town>Nombela</Town>
+					<Province>Toledo</Province>
+					<CountryCode>ESP</CountryCode>
+				</AddressInSpain>
+				<ContactDetails>
+					<ElectronicMail>bfn25xf3p@lycos.co.uk</ElectronicMail>
+				</ContactDetails>
+			</LegalEntity>
+		</BuyerParty>
+	</Parties>
+	<Invoices>
+		<Invoice>
+			<InvoiceHeader>
+				<InvoiceNumber>TEST01001A</InvoiceNumber>
+				<InvoiceDocumentType>FC</InvoiceDocumentType>
+				<InvoiceClass>OO</InvoiceClass>
+			</InvoiceHeader>
+			<InvoiceIssueData>
+				<IssueDate>2021-12-08</IssueDate>
+				<OperationDate>2021-12-08</OperationDate>
+				<InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+				<TaxCurrencyCode>EUR</TaxCurrencyCode>
+				<LanguageName>es</LanguageName>
+			</InvoiceIssueData>
+			<TaxesOutputs>
+				<Tax>
+					<TaxTypeCode>01</TaxTypeCode>
+					<TaxRate>21.0</TaxRate>
+					<TaxableBase>
+						<TotalAmount>4000.00</TotalAmount>
+					</TaxableBase>
+					<TaxAmount>
+						<TotalAmount>840.00</TotalAmount>
+					</TaxAmount>
+				</Tax>
+			</TaxesOutputs>
+			<InvoiceTotals>
+				<TotalGrossAmount>4000.00</TotalGrossAmount>
+				<TotalGrossAmountBeforeTaxes>4000.00</TotalGrossAmountBeforeTaxes>
+				<TotalTaxOutputs>840.00</TotalTaxOutputs>
+				<TotalTaxesWithheld>0.00</TotalTaxesWithheld>
+				<InvoiceTotal>4840.00</InvoiceTotal>
+				<PaymentsOnAccount>
+					<PaymentOnAccount>
+						<PaymentOnAccountDate>2021-11-01</PaymentOnAccountDate>
+						<PaymentOnAccountAmount>1000.00</PaymentOnAccountAmount>
+					</PaymentOnAccount>
+				</PaymentsOnAccount>
+				<TotalOutstandingAmount>3840.00</TotalOutstandingAmount>
+				<TotalPaymentsOnAccount>1000.00</TotalPaymentsOnAccount>
+				<TotalExecutableAmount>3840.00</TotalExecutableAmount>
+			</InvoiceTotals>
+			<Items>
+				<InvoiceLine>
+					<ItemDescription>Operations and development - day rate</ItemDescription>
+					<Quantity>20</Quantity>
+					<UnitPriceWithoutTax>200</UnitPriceWithoutTax>
+					<TotalCost>4000.00</TotalCost>
+					<GrossAmount>4000.00</GrossAmount>
+					<TaxesOutputs>
+						<Tax>
+							<TaxTypeCode>01</TaxTypeCode>
+							<TaxRate>21.0</TaxRate>
+							<TaxableBase>
+								<TotalAmount>4000.00</TotalAmount>
+							</TaxableBase>
+							<TaxAmount>
+								<TotalAmount>840.00</TotalAmount>
+							</TaxAmount>
+						</Tax>
+					</TaxesOutputs>
+				</InvoiceLine>
+			</Items>
+			<PaymentDetails>
+				<Installment>
+					<InstallmentDueDate>2021-12-30</InstallmentDueDate>
+					<InstallmentAmount>3840.00</InstallmentAmount>
+					<PaymentMeans>04</PaymentMeans>
+					<AccountToBeCredited>
+						<IBAN>ES25 0188 2570 7185 4470 4761</IBAN>
+					</AccountToBeCredited>
+				</Installment>
+			</PaymentDetails>
+		</Invoice>
+	</Invoices>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-7b2a6f80-7483-11ec-9722-7ea2cb436ff6" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>MdJxdBHiYALRIo9EsNv2GIM+udV0b2ndNFKKPjfJYvnITGA3lJnJ3+lVFtO2pM7psTOP6i8odulvlfOLtPzvOw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-7b2a6f80-7483-11ec-9722-7ea2cb436ff6">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>RaX2q62GjDghw56DyH1b4LBw7LEm+Arez2pk8X4Aa8H+Z3iuKTpN/7109DNaZZ+Yv1L1EIlbBaJSdzPqAFugaA==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>lNDHqvJ5FgwzQFl4Uj2x0BVdgaqLDEmt9Fh5i2cJfogEZhCSW+ZXocrML0uajU/v010A2eCJWDMRP4dEH295LA==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-SignatureValue">qjNzwq0+ovuEgScHgba2MBKZOPrAe9EHPF7zYLesYiMmgrSt7E+GyjqPTZ4iU9eQxwCrO5yEMGPO2ItilBd4RqmjLOA9bIDzd8DqpVvlNqSs03aQJNj0aF2ohCG8QVnsI9nlVpnPSgmq79NRew8aaB6CSytKZf3MjwBsRLQuANjeoluyZ2Of5WJNU+kTQ7jnnlWu2xa0dJfq9EZLEM1RxyWeRm+tUoqK+VxW8kSrhjLmV0CVRKADfYJ0HGRDf4Tq1D1uQWXoPE0XSXaidlmLRAdn/ZkOsRBacNZ/csHr9jv7KDmxa1IX4bL1L1G05SnxSSyc5tin4TOXjUCV4GHMmg==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-7b2a6f80-7483-11ec-9722-7ea2cb436ff6">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-QualifyingProperties" Target="#Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-Signature">
+				<xades:SignedProperties Id="Signature-7b2a6f80-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2025-01-01T00:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+						<xades:SignaturePolicyIdentifier>
+							<xades:SignaturePolicyId>
+								<xades:SigPolicyId>
+									<xades:Identifier>http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf</xades:Identifier>
+									<xades:Description>Política de Firma FacturaE v3.1</xades:Description>
+								</xades:SigPolicyId>
+								<xades:SigPolicyHash>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"></ds:DigestMethod>
+									<ds:DigestValue>Ohixl6upD6av8N7pEvDABhEL6hM=</ds:DigestValue>
+								</xades:SigPolicyHash>
+							</xades:SignaturePolicyId>
+						</xades:SignaturePolicyIdentifier>
+						<xades:SignerRole>
+							<xades:ClaimedRoles>
+								<xades:ClaimedRole>third party</xades:ClaimedRole>
+							</xades:ClaimedRoles>
+						</xades:SignerRole>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-7b2a6f80-7483-11ec-9722-7ea2cb436ff6">
+							<xades:Description>Factura Electrónica</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</fe:Facturae>


### PR DESCRIPTION
## Summary
`setAdvances` built each `PaymentOnAccount` struct but never appended it to the slice, so the `<PaymentsOnAccount>` block was always omitted from the XML even when non-grant advances existed on the invoice. Add the missing `append`.

Extracted from #16 (issue #1 of that PR's three bundled fixes).

## Test plan
- [x] `go test .` passes with the new `invoice-with-advance` fixture
- [x] `go test -tags xsdvalidate .` passes (XML is XSD-valid against Facturae v3.2.2)
- [x] Reverting the one-line `append` makes the fixture test fail (missing `<PaymentsOnAccount>` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)